### PR TITLE
Allow for generation of optional fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
-## 0.1.0
- * Initial release, extracted from schema.experimental in the main repo.
+## 0.1.2
+ * Allow for generation of non-required fields
 
+## 0.1.1
+ * Initial release, extracted from schema.experimental in the main repo.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 0.1.2
  * Allow for generation of non-required fields
 
-## 0.1.1
+## 0.1.0
  * Initial release, extracted from schema.experimental in the main repo.

--- a/project.clj
+++ b/project.clj
@@ -1,11 +1,11 @@
-(defproject prismatic/schema-generators "0.1.1-SNAPSHOT"
+(defproject prismatic/schema-generators "0.1.2-SNAPSHOT"
   :description "Clojure(Script) library for data generation from schemas"
   :url "http://github.com/plumatic/schema-generators"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
 
   :dependencies [[org.clojure/test.check "0.9.0"]
-                 [prismatic/schema "1.1.0"]]
+                 [prismatic/schema "1.1.6"]]
 
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.8.0"]
                                   [org.clojure/clojurescript "1.7.228"]]

--- a/src/schema_generators/complete.cljc
+++ b/src/schema_generators/complete.cljc
@@ -19,15 +19,17 @@
 ;;; Private helpers
 
 (defprotocol Completer
-  (completer* [spec s sub-checker generator-opts]
-    "A function applied to a datum as part of coercion to complete missing fields."))
+  (completer* [spec s sub-checker generator-opts include-optional?]
+    "A function applied to a datum as part of coercion to complete missing fields.
+
+    Entries with optional fields will be generated when `include-optional?` is set"))
 
 (defn sample [g]
   (check-generators/generate g 10))
 
 (extend-protocol Completer
   schema.spec.variant.VariantSpec
-  (completer* [spec s sub-checker generator-opts]
+  (completer* [spec s sub-checker generator-opts include-optional?]
     (let [g (apply generators/generator s generator-opts)]
       (if (when-let [cs (utils/class-schema s)]
             (instance? schema.core.Record cs))
@@ -39,10 +41,13 @@
             (sub-checker x))))))
 
   schema.spec.collection.CollectionSpec
-  (completer* [spec s sub-checker generator-opts]
+  (completer* [spec s sub-checker generator-opts include-optional?]
     (if (instance? #?(:clj clojure.lang.APersistentMap :cljs cljs.core/PersistentArrayMap)
                    s) ;; todo: pluggable
-      (let [g (apply generators/generator s generator-opts)]
+      (let [g (apply generators/generator s generator-opts)
+            required-filter (if include-optional?
+                              identity
+                              #(filter s/required-key? %))]
         (fn map-completer [x]
           (if (= +missing+ x)
             (sample g)
@@ -50,7 +55,7 @@
             (let [ks (distinct (concat (keys x)
                                        (->> s
                                             keys
-                                            (filter s/required-key?)
+                                            required-filter
                                             (map s/explicit-schema-key))))]
               (sub-checker
                (into {} (for [k ks] [k (get x k +missing+)])))))))
@@ -61,7 +66,7 @@
             (sub-checker x))))))
 
   schema.spec.leaf.LeafSpec
-  (completer* [spec s sub-checker generator-opts]
+  (completer* [spec s sub-checker generator-opts include-optional?]
     (let [g (apply generators/generator s generator-opts)]
       (fn leaf-completer [x]
         (if (= +missing+ x)
@@ -82,11 +87,17 @@
     coercion-matcher :- coerce/CoercionMatcher
     leaf-generators :- generators/LeafGenerators
     wrappers :- generators/GeneratorWrappers]
+   (completer schema coercion-matcher leaf-generators wrappers false))
+  ([schema
+    coercion-matcher :- coerce/CoercionMatcher
+    leaf-generators :- generators/LeafGenerators
+    wrappers :- generators/GeneratorWrappers
+    include-optional? :- s/Bool]
    (spec/run-checker
     (fn [s params]
       (let [c (spec/checker (s/spec s) params)
             coercer (or (coercion-matcher s) identity)
-            completr (completer* (s/spec s) s c [leaf-generators wrappers])]
+            completr (completer* (s/spec s) s c [leaf-generators wrappers] include-optional?)]
         (fn [x]
           (macros/try-catchall
            (let [v (coercer x)]

--- a/src/schema_generators/generators.cljc
+++ b/src/schema_generators/generators.cljc
@@ -37,9 +37,10 @@
   (if (vector? e)
     (case (first e)
       ::schema.spec.collection/optional
-      (generators/one-of
-       [(generators/return nil)
-        (elements-generator (next e) params)])
+      (let [choices (if (:include-optional? params)
+                      [(elements-generator (next e) params)]
+                      [(generators/return nil) (elements-generator (next e) params)])]
+        (generators/one-of choices))
 
       ::schema.spec.collection/remaining
       (do (macros/assert! (= 2 (count e)) "remaining can have only one schema.")
@@ -204,6 +205,11 @@
   ([schema :- Schema
     leaf-generators :- LeafGenerators
     wrappers :- GeneratorWrappers]
+   (generator schema leaf-generators wrappers {}))
+  ([schema :- Schema
+    leaf-generators :- LeafGenerators
+    wrappers :- GeneratorWrappers
+    auxilary-opts :- {s/Keyword s/Any}]
      (let [leaf-generators (default-leaf-generators leaf-generators)
            gen (fn [s params]
                  ((or (wrappers s) identity)
@@ -211,8 +217,10 @@
                       (composite-generator (s/spec s) params))))]
        (generators/fmap
         (s/validator schema)
-        (gen schema {:subschema-generator gen :cache #?(:clj (java.util.IdentityHashMap.)
-                                                        :cljs (atom {}))})))))
+        (gen schema (merge {:subschema-generator gen
+                            :cache #?(:clj (java.util.IdentityHashMap.)
+                                      :cljs (atom {}))}
+                           auxilary-opts))))))
 
 (s/defn sample :- [s/Any]
   "Sample k elements from generator."

--- a/test/schema_generators/complete_test.cljc
+++ b/test/schema_generators/complete_test.cljc
@@ -21,10 +21,19 @@
 
 (deftest optional-key-complete-test
   (let [s {:a s/Int (s/optional-key :b) s/Str}
-        ex-without-optional-keys (complete/complete {} s {} {} {} false)
-        ex-including-optional-keys (complete/complete {} s {} {} {} true)]
-    (is (nil? (:b ex-without-optional-keys)))
-    (is (string? (:b ex-including-optional-keys)))))
+        without-opt-keys (complete/complete {} s {} {} {})
+        including-opt-keys (complete/complete {} s {} {} {} {:include-optional? true})]
+    (is (not (contains? without-opt-keys :b)))
+    (is (string? (:b including-opt-keys)))))
+
+(deftest nested-optional-key-complete-test
+  (let [inner-schema {(s/optional-key :inner) s/Str}
+        outer-schema {:outer-a s/Int :outer-b inner-schema}
+        without-opt-keys (complete/complete {} outer-schema {} {} {:include-optional? false})
+        including-opt-keys (complete/complete {} outer-schema {} {} {} {:include-optional? true})]
+    ;; TODO: this test fails (non-deterministically) due to bug in the implementation
+    (is (not (contains? (:outer-b without-opt-keys) :inner)))
+    (is (string? (-> including-opt-keys :outer-b :inner)))))
 
 (s/defschema Animal
   (abstract-map/abstract-map-schema

--- a/test/schema_generators/complete_test.cljc
+++ b/test/schema_generators/complete_test.cljc
@@ -28,10 +28,9 @@
 
 (deftest nested-optional-key-complete-test
   (let [inner-schema {(s/optional-key :inner) s/Str}
-        outer-schema {:outer-a s/Int :outer-b inner-schema}
+        outer-schema {:outer-a s/Int (s/optional-key :outer-b) inner-schema}
         without-opt-keys (complete/complete {} outer-schema {} {} {:include-optional? false})
         including-opt-keys (complete/complete {} outer-schema {} {} {} {:include-optional? true})]
-    ;; TODO: this test fails (non-deterministically) due to bug in the implementation
     (is (not (contains? (:outer-b without-opt-keys) :inner)))
     (is (string? (-> including-opt-keys :outer-b :inner)))))
 

--- a/test/schema_generators/complete_test.cljc
+++ b/test/schema_generators/complete_test.cljc
@@ -19,6 +19,13 @@
       (is (= "test" (complete/complete "test" s)))
       (is (integer? (:foo (complete/complete {} s)))))))
 
+(deftest optional-key-complete-test
+  (let [s {:a s/Int (s/optional-key :b) s/Str}
+        ex-without-optional-keys (complete/complete {} s {} {} {} false)
+        ex-including-optional-keys (complete/complete {} s {} {} {} true)]
+    (is (nil? (:b ex-without-optional-keys)))
+    (is (string? (:b ex-including-optional-keys)))))
+
 (s/defschema Animal
   (abstract-map/abstract-map-schema
    :type


### PR DESCRIPTION
At times I would like to generate examples of a schema that include all fields declared in that schema. This currently isn't possible. This PR adds a flag argument that changes the behavior of `complete` to include entries for optional keys.

```clojure
(require '[schema-generators.complete :as complete])
(require '[schema.core :as s])

;; before
(complete/complete {} {:req-int s/Int (s/optional-key :opt-str) s/Str} {} {} {})
;; => {:req-int -167}

;; after
(complete/complete {} {:req-int s/Int (s/optional-key :opt-str) s/Str} {} {} {})
;; => {:req-int -38}
(complete/complete {} {:req-int s/Int (s/optional-key :opt-str) s/Str} {} {} {} true)
;; => {:opt-str "CvD^qv8" :req-int -15}
```

Note: haven't run ClojureScript test suite yet; I'll take the time to setup the env it this PR 