### PR TITLE
Fix keyword syntax to support Clojure 1.9.0-alpha18

### DIFF
--- a/src/schema_generators/generators.cljc
+++ b/src/schema_generators/generators.cljc
@@ -36,12 +36,12 @@
 (defn element-generator [e params]
   (if (vector? e)
     (case (first e)
-      ::schema.spec.collection/optional
+      :schema.spec.collection/optional
       (generators/one-of
        [(generators/return nil)
         (elements-generator (next e) params)])
 
-      ::schema.spec.collection/remaining
+      :schema.spec.collection/remaining
       (do (macros/assert! (= 2 (count e)) "remaining can have only one schema.")
           (generators/vector (sub-generator (second e) params))))
     (generators/fmap vector (sub-generator e params))))


### PR DESCRIPTION
From Clojure 1.9.0-alpha18 changelog:
* Tighten autoresolved keywords and autoresolved namespace map syntax to support only aliases, as originally intended

This results in the following exception when trying to load `schema-generators` on 1.9.0-alpha18 and later:
```clojure
#error {
 :cause "Invalid token: ::schema.spec.collection/optional"
 :via
 [{:type clojure.lang.Compiler$CompilerException
   :message "java.lang.RuntimeException: Invalid token: ::schema.spec.collection/optional, compiling:(schema_generators/generators.cljc:40:0)"
   :at [clojure.lang.Compiler load "Compiler.java" 7464]}
  {:type java.lang.RuntimeException
   :message "Invalid token: ::schema.spec.collection/optional"
   :at [clojure.lang.Util runtimeException "Util.java" 221]}]
   :trace [...]}
```