### PR TITLE
Add ability to specify generator size and seed

### DIFF
--- a/src/schema_generators/generators.cljc
+++ b/src/schema_generators/generators.cljc
@@ -2,6 +2,7 @@
   "Experimental support for compiling schemas to test.check generators."
   (:require
    [clojure.test.check.generators :as generators]
+   [clojure.test.check.rose-tree :as rose]
    [schema.spec.core :as spec :include-macros true]
    schema.spec.collection
    schema.spec.leaf
@@ -223,3 +224,17 @@
   "Sample a single element of low to moderate size."
   [& generator-args]
   (generators/generate (apply generator generator-args) 10))
+
+(s/defn generate-alt :- s/Any
+  "Sample a single element
+
+  Providing the same random seed will give the same result"
+  ([schema random-seed] (generate-alt schema random-seed 10))
+  ([schema random-seed size] (generate-alt schema random-seed size {} {}))
+  ([schema :- Schema
+    random-seed
+    size :- s/Int
+    leaf-generators :- LeafGenerators
+    wrappers :- GeneratorWrappers]
+   (let [gen (generator schema leaf-generators wrappers)]
+     (rose/root (generators/call-gen gen random-seed size)))))

--- a/test/schema_generators/generators_test.cljc
+++ b/test/schema_generators/generators_test.cljc
@@ -5,6 +5,7 @@
    [clojure.test.check]
    [clojure.test.check.properties :as properties :include-macros true]
    [clojure.test.check.generators :as check-generators]
+   [clojure.test.check.random :as random]
    [clojure.test.check.clojure-test #?@(:clj [:refer [defspec]]
                                         :cljs [:refer-macros [defspec]])]
    [schema.core :as s :include-macros true]
@@ -64,3 +65,15 @@
   50
   (properties/for-all [x (generators/generator OGSchema)]
                       (not (s/check OGSchema x))))
+
+(deftest generate-alt-test
+  (let [random-seed (random/make-random)
+        other-seed  (random/make-random)
+        res-a (generators/generate-alt OGSchema random-seed 15)
+        res-b (generators/generate-alt OGSchema random-seed 15)
+        res-c (generators/generate-alt OGSchema random-seed 10)
+        res-d (generators/generate-alt OGSchema other-seed 15)]
+    (is (= res-a res-b) "samples generated with same seed and size are the same")
+    (is (not (= res-a res-c)) "samples generated with same seed and diff. size are diff.")
+    (is (not (= res-a res-d)) "samples generated with diff. seed and same size are diff.")
+    (is (s/validate OGSchema res-a))))


### PR DESCRIPTION
Every once in a while I'm trying to generate a fairly constrained schema and I get an error that after 10 tries an example couldn't be generated (if I find the error I will paste it here). Extending the user to pass in a sample size will allow them to hand tune this for problematic schemas.

While I was at it I figured I would address https://github.com/plumatic/schema-generators/issues/7