### PR TITLE
Use built-in symbol generator

### DIFF
--- a/src/schema_generators/generators.cljc
+++ b/src/schema_generators/generators.cljc
@@ -128,7 +128,7 @@
     s/Keyword generators/keyword
     #?(:clj clojure.lang.Keyword
        :cljs cljs.core/Keyword) generators/keyword
-    s/Symbol (generators/fmap (comp symbol name) generators/keyword)
+    s/Symbol generators/symbol
     #?(:clj Object :cljs js/Object) generators/any
     s/Any generators/any
     s/Uuid generators/uuid

--- a/test/schema_generators/generators_test.cljc
+++ b/test/schema_generators/generators_test.cljc
@@ -64,3 +64,7 @@
   50
   (properties/for-all [x (generators/generator OGSchema)]
                       (not (s/check OGSchema x))))
+
+(defspec readable-symbols-spec 1000
+  (properties/for-all [x (generators/generator s/Symbol)]
+    (-> x str read-string (= x))))


### PR DESCRIPTION
Adapting the keyword generator results in unreadable symbols when
they start with e.g. `+4`