### PR TITLE
Wildcard keys with specific keys 2

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
 
   :dependencies [[org.clojure/test.check "0.9.0"]
-                 [prismatic/schema "1.1.7"]]
+                 [prismatic/schema "1.1.11"]]
 
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.8.0"]
                                   [org.clojure/clojurescript "1.10.520"]]

--- a/test/schema_generators/generators_test.cljc
+++ b/test/schema_generators/generators_test.cljc
@@ -69,3 +69,14 @@
 (defspec readable-symbols-spec 1000
   (properties/for-all [x (generators/generator s/Symbol)]
     (-> x str read-string (= x))))
+
+(def Issue16RegressionSchema
+  "A map where the wildcard keys are likely to collide with the
+  specific keys."
+  {:x                s/Int
+   (s/enum :x :y :z) s/Bool})
+
+;; regression test for issue #16
+(defspec can-mix-wildcard-keys-with-specific-keys 50
+  (properties/for-all [m (generators/generator Issue16RegressionSchema)]
+    (is (number? (:x m)))))


### PR DESCRIPTION
Adds a failing regression test for #16 and then bumps the schema dep to get it to pass.

This doesn't strictly require a release, but I'll do one anyhow, at least in case there are
people who like to minimize their dependency conflicts.