### PR TITLE
Smoke test schema + cljc

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,8 +4,9 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
 
+  :exclusions [prismatic/schema]
   :dependencies [[org.clojure/test.check "0.9.0"]
-                 [prismatic/schema "1.1.11"]]
+                 [org.clojars.frenchy64/schema "1.1.13-20211021.171347-1"]]
 
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.8.0"]
                                   [org.clojure/clojurescript "1.10.520"]]


### PR DESCRIPTION
Try https://github.com/plumatic/schema/pull/426

```
$ lein all test
OpenJDK 64-Bit Server VM warning: Options -Xverify:none and -noverify were deprecated in JDK 13 and will likely be
removed in a future release.
Performing task 'test' with profile(s): 'dev'

lein test schema-generators.complete-test

lein test schema-generators.generators-test
{:result true, :num-tests 1000, :seed 1634929394356, :test-var "readable-symbols-spec"}
{:result true, :num-tests 50, :seed 1634929396911, :test-var "can-mix-wildcard-keys-with-specific-keys"}
{:result true, :num-tests 50, :seed 1634929396926, :test-var "spec-test"}

Ran 8 tests containing 104 assertions.
0 failures, 0 errors.

;; ======================================================================
;; Testing with Node:


Testing schema-generators.generators-test
{:result true, :num-tests 50, :seed 1634929410627, :test-var "spec-test"}
{:result true, :num-tests 1000, :seed 1634929418825, :test-var "readable-symbols-spec"}
{:result true, :num-tests 50, :seed 1634929471578, :test-var "can-mix-wildcard-keys-with-specific-keys"}

Testing schema-generators.complete-test

Ran 8 tests containing 79 assertions.
0 failures, 0 errors.
Performing task 'test' with profile(s): 'dev,1.9'

lein test schema-generators.complete-test

lein test schema-generators.generators-test
{:result true, :num-tests 1000, :seed 1634929480568, :test-var "readable-symbols-spec"}
{:result true, :num-tests 50, :seed 1634929483106, :test-var "can-mix-wildcard-keys-with-specific-keys"}
{:result true, :num-tests 50, :seed 1634929483125, :test-var "spec-test"}

Ran 8 tests containing 104 assertions.
0 failures, 0 errors.

;; ======================================================================
;; Testing with Node:


Testing schema-generators.generators-test
{:result true, :num-tests 50, :seed 1634929490042, :test-var "spec-test"}
{:result true, :num-tests 1000, :seed 1634929497265, :test-var "readable-symbols-spec"}
{:result true, :num-tests 50, :seed 1634929550695, :test-var "can-mix-wildcard-keys-with-specific-keys"}

Testing schema-generators.complete-test

Ran 8 tests containing 79 assertions.
0 failures, 0 errors.
Performing task 'test' with profile(s): 'dev,1.10'

lein test schema-generators.complete-test

lein test schema-generators.generators-test
{:result true, :num-tests 1000, :seed 1634929560095, :test-var "readable-symbols-spec"}
{:result true, :num-tests 50, :seed 1634929562612, :test-var "can-mix-wildcard-keys-with-specific-keys"}
{:result true, :num-tests 50, :seed 1634929562626, :test-var "spec-test"}

Ran 8 tests containing 104 assertions.
0 failures, 0 errors.

;; ======================================================================
;; Testing with Node:


Testing schema-generators.generators-test
{:result true, :num-tests 50, :seed 1634929568920, :test-var "spec-test"}
{:result true, :num-tests 1000, :seed 1634929574570, :test-var "readable-symbols-spec"}
{:result true, :num-tests 50, :seed 1634929620076, :test-var "can-mix-wildcard-keys-with-specific-keys"}

Testing schema-generators.complete-test

Ran 8 tests containing 79 assertions.
0 failures, 0 errors.
```