### PR TITLE
Implement such-that maximum retries option

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
   :dependencies [[org.clojure/test.check "0.9.0"]
                  [prismatic/schema "1.2.1"]]
 
-  :profiles {:dev {:dependencies [[org.clojure/clojure "1.8.0"]
+  :profiles {:dev {:dependencies [[org.clojure/clojure "1.11.1"]
                                   [org.clojure/clojurescript "1.10.520"]]
                    :plugins [[lein-codox "0.9.4"]
                              [lein-release/lein-release "1.0.4"]]}

--- a/src/schema_generators/generators.cljc
+++ b/src/schema_generators/generators.cljc
@@ -64,8 +64,8 @@
        (let [pre (.-pre ^schema.spec.variant.VariantSpec s)
              post (.-post ^schema.spec.variant.VariantSpec s)]
          (not
-           (or (pre x)
-               (and post (post x))))))
+          (or (pre x)
+              (and post (post x))))))
      (generators/one-of
        (for [o (macros/safe-get s :options)]
          (if-let [g (:guard o)]
@@ -77,7 +77,7 @@
   ;; both specific keys and key schemas that can override them.
   schema.spec.collection.CollectionSpec
   (composite-generator [s params]
-   (generators/such-that
+    (generators/such-that
      (complement (.-pre ^schema.spec.collection.CollectionSpec s))
      (generators/fmap (:konstructor s) (elements-generator (:elements s) params))
      (:max-retries params)))
@@ -131,9 +131,9 @@
     s/Bool generators/boolean
     s/Num (generators/one-of [generators/large-integer generators/double])
     s/Int (generators/one-of
-            [generators/large-integer
-             #?@(:clj [(generators/fmap unchecked-int generators/large-integer)
-                       (generators/fmap bigint generators/large-integer)])])
+           [generators/large-integer
+            #?@(:clj [(generators/fmap unchecked-int generators/large-integer)
+                      (generators/fmap bigint generators/large-integer)])])
     s/Keyword generators/keyword
     #?(:clj clojure.lang.Keyword
        :cljs cljs.core/Keyword) (generators/one-of [generators/keyword generators/keyword-ns])
@@ -153,8 +153,8 @@
                                    [booleans boolean-array Boolean]]]
                    [f (generators/fmap ctor
                                        (generators/vector
-                                         (macros/safe-get
-                                           +primitive-generators+ c)))])))))
+                                        (macros/safe-get
+                                         +primitive-generators+ c)))])))))
 
 
 (defn eq-generators [s]

--- a/src/schema_generators/generators.cljc
+++ b/src/schema_generators/generators.cljc
@@ -208,9 +208,9 @@
   ([schema]
    (generator schema {:max-retries 10}))
   ([schema opts]
-     (generator schema opts {}))
+   (generator schema opts {}))
   ([schema opts leaf-generators]
-     (generator schema opts leaf-generators {}))
+   (generator schema opts leaf-generators {}))
   ([schema :- Schema
     opts :- Options
     leaf-generators :- LeafGenerators

--- a/test/schema_generators/generators_test.cljc
+++ b/test/schema_generators/generators_test.cljc
@@ -14,7 +14,7 @@
 
 (def OGInner
   {(s/required-key "l") [s/Int]
-   s/Keyword            s/Str})
+   s/Keyword s/Str})
 
 (def OGInner2
   {:c OGInner
@@ -31,25 +31,25 @@
 
 (deftest sample-test
   (let [res (generators/sample
-              20 OGSchema
-              {[s/Str] (generators/always ["bob"])
-               s/Int   ((generators/fmap #(inc (* % 2))) check-generators/int)}
-              {[s/Int]  (comp (generators/such-that seq)
-                              (generators/fmap (partial mapv inc)))
-               OGInner2 (generators/merged {:d "mary"})})]
+             20 OGSchema
+             {[s/Str] (generators/always ["bob"])
+              s/Int ((generators/fmap #(inc (* % 2))) check-generators/int)}
+             {[s/Int] (comp (generators/such-that seq)
+                            (generators/fmap (partial mapv inc)))
+              OGInner2 (generators/merged {:d "mary"})})]
     (is (= (count res) 20))
     (is (s/validate [FinalSchema] res))))
 
 (deftest simple-leaf-generators-smoke-test
-  (doseq [leaf-schema [#?@(:clj  [double float long int short char byte boolean
-                                  Double Float Long Integer Short Character Byte Boolean
-                                  doubles floats longs ints shorts chars bytes booleans
-                                  String Object]
+  (doseq [leaf-schema [#?@(:clj [double float long int short char byte boolean
+                                 Double Float Long Integer Short Character Byte Boolean
+                                 doubles floats longs ints shorts chars bytes booleans
+                                 String Object]
                            :cljs [js/Object])
                        s/Str s/Bool s/Num s/Int s/Keyword s/Symbol s/Inst
                        s/Any s/Uuid (s/eq "foo") (s/enum :a :b :c)]]
-    (testing (str leaf-schema)
-      (is (= 10 (count (generators/sample 10 leaf-schema)))))))
+      (testing (str leaf-schema)
+        (is (= 10 (count (generators/sample 10 leaf-schema)))))))
 
 (def FancySeq
   "A sequence that starts with a String, followed by an optional Keyword,
@@ -65,7 +65,7 @@
 (defspec spec-test
   50
   (properties/for-all [x (generators/generator OGSchema)]
-    (not (s/check OGSchema x))))
+                      (not (s/check OGSchema x))))
 
 (defspec readable-symbols-spec 1000
   (properties/for-all [x (generators/generator s/Symbol)]

--- a/test/schema_generators/generators_test.cljc
+++ b/test/schema_generators/generators_test.cljc
@@ -1,19 +1,20 @@
 (ns schema-generators.generators-test
   #?(:clj (:use clojure.test))
   (:require
-   #?(:cljs [cljs.test :refer-macros [deftest is testing run-tests]])
-   #?(:cljs [cljs.reader :refer [read-string]])
-   [clojure.test.check]
-   [clojure.test.check.properties :as properties :include-macros true]
-   [clojure.test.check.generators :as check-generators]
-   [clojure.test.check.clojure-test #?@(:clj [:refer [defspec]]
-                                        :cljs [:refer-macros [defspec]])]
-   [schema.core :as s :include-macros true]
-   [schema-generators.generators :as generators]))
+    #?(:cljs [cljs.test :refer-macros [deftest is testing run-tests]])
+    #?(:cljs [cljs.reader :refer [read-string]])
+    [clojure.test.check]
+    [clojure.test.check.properties :as properties :include-macros true]
+    [clojure.test.check.generators :as check-generators]
+    [clojure.test.check.clojure-test #?@(:clj  [:refer [defspec]]
+                                         :cljs [:refer-macros [defspec]])]
+    [schema.core :as s :include-macros true]
+    [schema-generators.generators :as generators])
+  (:import (clojure.lang ExceptionInfo)))
 
 (def OGInner
   {(s/required-key "l") [s/Int]
-   s/Keyword s/Str})
+   s/Keyword            s/Str})
 
 (def OGInner2
   {:c OGInner
@@ -30,25 +31,25 @@
 
 (deftest sample-test
   (let [res (generators/sample
-             20 OGSchema
-             {[s/Str] (generators/always ["bob"])
-              s/Int ((generators/fmap #(inc (* % 2))) check-generators/int)}
-             {[s/Int] (comp (generators/such-that seq)
-                            (generators/fmap (partial mapv inc)))
-              OGInner2 (generators/merged {:d "mary"})})]
+              20 OGSchema
+              {[s/Str] (generators/always ["bob"])
+               s/Int   ((generators/fmap #(inc (* % 2))) check-generators/int)}
+              {[s/Int]  (comp (generators/such-that seq)
+                              (generators/fmap (partial mapv inc)))
+               OGInner2 (generators/merged {:d "mary"})})]
     (is (= (count res) 20))
     (is (s/validate [FinalSchema] res))))
 
 (deftest simple-leaf-generators-smoke-test
-  (doseq [leaf-schema [#?@(:clj [double float long int short char byte boolean
-                                 Double Float Long Integer Short Character Byte Boolean
-                                 doubles floats longs ints shorts chars bytes booleans
-                                 String Object]
+  (doseq [leaf-schema [#?@(:clj  [double float long int short char byte boolean
+                                  Double Float Long Integer Short Character Byte Boolean
+                                  doubles floats longs ints shorts chars bytes booleans
+                                  String Object]
                            :cljs [js/Object])
                        s/Str s/Bool s/Num s/Int s/Keyword s/Symbol s/Inst
                        s/Any s/Uuid (s/eq "foo") (s/enum :a :b :c)]]
-      (testing (str leaf-schema)
-        (is (= 10 (count (generators/sample 10 leaf-schema)))))))
+    (testing (str leaf-schema)
+      (is (= 10 (count (generators/sample 10 leaf-schema)))))))
 
 (def FancySeq
   "A sequence that starts with a String, followed by an optional Keyword,
@@ -64,7 +65,7 @@
 (defspec spec-test
   50
   (properties/for-all [x (generators/generator OGSchema)]
-                      (not (s/check OGSchema x))))
+    (not (s/check OGSchema x))))
 
 (defspec readable-symbols-spec 1000
   (properties/for-all [x (generators/generator s/Symbol)]
@@ -80,3 +81,20 @@
 (defspec can-mix-wildcard-keys-with-specific-keys 50
   (properties/for-all [m (generators/generator Issue16RegressionSchema)]
     (is (number? (:x m)))))
+
+(def FailRetries
+  (s/conditional
+    int? s/Str))
+
+(deftest maximum-retries-test
+  (is (thrown-with-msg?
+        ExceptionInfo #"Couldn't satisfy such-that predicate after 100 tries."
+        (generators/generate FailRetries {:max-retries 100})))
+
+  (is (thrown-with-msg?
+        ExceptionInfo #"Couldn't satisfy such-that predicate after 50 tries."
+        (generators/generate FailRetries {:max-retries 50})))
+
+  (is (thrown-with-msg?
+        ExceptionInfo #"Couldn't satisfy such-that predicate after 10 tries."
+        (generators/generate FailRetries))))

--- a/test/schema_generators/generators_test.cljc
+++ b/test/schema_generators/generators_test.cljc
@@ -10,7 +10,7 @@
                                          :cljs [:refer-macros [defspec]])]
     [schema.core :as s :include-macros true]
     [schema-generators.generators :as generators])
-  (:import (clojure.lang ExceptionInfo)))
+  #?(:clj (:import (clojure.lang ExceptionInfo))))
 
 (def OGInner
   {(s/required-key "l") [s/Int]


### PR DESCRIPTION
## Context

`clojure.test.check` has the option to increase the maximum number of retries for generators. When creating complex schemas, you may face flakiness of generators and tests because of `conditionals` and other types of constraints. If the reader is interested in reading more about the context, the issue opened https://github.com/plumatic/schema-generators/issues/28 has more context.

## Changes

To enable configuration of `max-retries` on [such-that](https://github.com/clojure/test.check/blob/0d926302479c06b748c963955844bb82cf4371fb/src/main/clojure/clojure/test/check/generators.cljc#L440).

Changes:
* Overload the function schema-generators.generators/generator to allow a new argument named `opts` to be provided as options (enabling further extension required).
* Change the `CompositeGenerator` protocol to accept `opts` as argument
* Implement tests for maximum number of retries and guarantee the existing tests are working
* Bump clojure to `1.11.1`